### PR TITLE
Add Historical data

### DIFF
--- a/packages/api-tests/tests/tenancy/test-historical-get-asset-balance.js
+++ b/packages/api-tests/tests/tenancy/test-historical-get-asset-balance.js
@@ -1,0 +1,24 @@
+const testenv = require('../../testenv.js');
+const partials = require('../../partials.js');
+
+// Shortcuts to most-used facilities.
+const {test, inspect} = testenv;
+
+const protocol = 'ethereum';
+const network = 'ropsten';
+
+test('Test retrieve native asset balance by address', async function(t) {
+  const to_addr = '0x93b3d0b2894e99c2934bed8586ea4e2b94ce6bfd';
+  let balance;
+  try {
+    tx = await testenv.tenancy.historical.get_asset_balance(protocol, network, to_addr);
+  } catch (error) {
+    return partials.tErrorFail(t, error, 'Retrieving the asset balance failed.');
+  }
+
+  t.ok(balance.address, 'balance has address field');
+  t.equal(balance.contract, undefined, 'Asset balance contract is null as expected');
+  t.equal(balance.address, to_addr, 'Asset address matches');
+
+  t.end();
+});

--- a/packages/api-tests/tests/tenancy/test-historical-get-asset-balance.js
+++ b/packages/api-tests/tests/tenancy/test-historical-get-asset-balance.js
@@ -11,7 +11,7 @@ test('Test retrieve native asset balance by address', async function(t) {
   const to_addr = '0x93b3d0b2894e99c2934bed8586ea4e2b94ce6bfd';
   let balance;
   try {
-    tx = await testenv.tenancy.historical.get_asset_balance(protocol, network, to_addr);
+    balance = await testenv.tenancy.historical.get_asset_balance(protocol, network, to_addr);
   } catch (error) {
     return partials.tErrorFail(t, error, 'Retrieving the asset balance failed.');
   }

--- a/packages/api-tests/tests/tenancy/test-historical-get-block.js
+++ b/packages/api-tests/tests/tenancy/test-historical-get-block.js
@@ -9,10 +9,9 @@ const network = 'ropsten';
 
 test('Test retrieve block details', async function(t) {
   t.comment('Test retrieving latest block number.');
-  const block_number = '6570890';
   let block;
   try {
-    block = await testenv.tenancy.historical.get_block(protocol, network, block);
+    block = await testenv.tenancy.historical.get_block(protocol, network, 'latest');
   } catch (error) {
     return partials.tErrorFail(t, error, 'Retrieving the block failed.');
   }
@@ -21,14 +20,13 @@ test('Test retrieve block details', async function(t) {
 
   t.comment('Test retrieving specific block number.');
   const block_number = 6570890;
-  let block;
   try {
-    block = await testenv.tenancy.historical.get_block(protocol, network, block);
+    block = await testenv.tenancy.historical.get_block(protocol, network, block_number);
   } catch (error) {
     return partials.tErrorFail(t, error, 'Retrieving the block failed.');
   }
 
-  t.equal(block.number, block_number, 'block.number matches expected block number');
+  t.equal(parseInt(block.number), block_number, 'block.number matches expected block number');
 
   t.end();
 });

--- a/packages/api-tests/tests/tenancy/test-historical-get-block.js
+++ b/packages/api-tests/tests/tenancy/test-historical-get-block.js
@@ -1,0 +1,34 @@
+const testenv = require('../../testenv.js');
+const partials = require('../../partials.js');
+
+// Shortcuts to most-used facilities.
+const {test, inspect} = testenv;
+
+const protocol = 'ethereum';
+const network = 'ropsten';
+
+test('Test retrieve block details', async function(t) {
+  t.comment('Test retrieving latest block number.');
+  const block_number = '6570890';
+  let block;
+  try {
+    block = await testenv.tenancy.historical.get_block(protocol, network, block);
+  } catch (error) {
+    return partials.tErrorFail(t, error, 'Retrieving the block failed.');
+  }
+
+  t.ok(block.number, 'block number for latest block is set');
+
+  t.comment('Test retrieving specific block number.');
+  const block_number = 6570890;
+  let block;
+  try {
+    block = await testenv.tenancy.historical.get_block(protocol, network, block);
+  } catch (error) {
+    return partials.tErrorFail(t, error, 'Retrieving the block failed.');
+  }
+
+  t.equal(block.number, block_number, 'block.number matches expected block number');
+
+  t.end();
+});

--- a/packages/api-tests/tests/tenancy/test-historical-get-contract-balance.js
+++ b/packages/api-tests/tests/tenancy/test-historical-get-contract-balance.js
@@ -13,7 +13,7 @@ test('Test retrieve contract asset balance by address', async function(t) {
 
   let balance;
   try {
-    tx = await testenv.tenancy.historical.get_contract_balance(
+    balance = await testenv.tenancy.historical.get_contract_balance(
       protocol,
       network,
       to_addr,
@@ -24,7 +24,7 @@ test('Test retrieve contract asset balance by address', async function(t) {
   }
 
   t.ok(balance.address, 'balance has address field');
-  t.equal(balance.contract, undefined, 'Contract balance contract is null as expected');
+  t.equal(balance.contract, contract_addr, 'Contract balance contract is set');
   t.equal(balance.address, to_addr, 'Contract address matches');
 
   t.end();

--- a/packages/api-tests/tests/tenancy/test-historical-get-contract-balance.js
+++ b/packages/api-tests/tests/tenancy/test-historical-get-contract-balance.js
@@ -1,0 +1,31 @@
+const testenv = require('../../testenv.js');
+const partials = require('../../partials.js');
+
+// Shortcuts to most-used facilities.
+const {test, inspect} = testenv;
+
+const protocol = 'ethereum';
+const network = 'ropsten';
+
+test('Test retrieve contract asset balance by address', async function(t) {
+  const to_addr = '0x93b3d0b2894e99c2934bed8586ea4e2b94ce6bfd';
+  const contract_addr = '0x1d7cf6ad190772cc6177beea2e3ae24cc89b2a10';
+
+  let balance;
+  try {
+    tx = await testenv.tenancy.historical.get_contract_balance(
+      protocol,
+      network,
+      to_addr,
+      contract_addr
+    );
+  } catch (error) {
+    return partials.tErrorFail(t, error, 'Retrieving the contract balance failed.');
+  }
+
+  t.ok(balance.address, 'balance has address field');
+  t.equal(balance.contract, undefined, 'Contract balance contract is null as expected');
+  t.equal(balance.address, to_addr, 'Contract address matches');
+
+  t.end();
+});

--- a/packages/api-tests/tests/tenancy/test-historical-get-status.js
+++ b/packages/api-tests/tests/tenancy/test-historical-get-status.js
@@ -10,14 +10,16 @@ const network = 'ropsten';
 test('Test retrieve protocol/network status', async function(t) {
   let status;
   try {
-    tx = await testenv.tenancy.historical.get_status(protocol, network, txhash);
+    status = await testenv.tenancy.historical.api_status(protocol, network);
   } catch (error) {
-    return partials.tErrorFail(t, error, 'Retrieving the status for ${protocol} ${network} failed');
+    return partials.tErrorFail(t, error, `Retrieving the status for ${protocol} ${network} failed`);
   }
 
-  sttausOK = [status.lowest, status.highest, status, latest].every((el, i, arr) => el !== null);
+  const statusOK = [status.lowest, status.highest, status.latest].every(
+    (el, i, arr) => el !== null
+  );
 
-  t.ok(statusOK, 'Sttaus OK');
+  t.ok(statusOK, `Status for ${protocol} ${network} OK`);
 
   t.end();
 });

--- a/packages/api-tests/tests/tenancy/test-historical-get-status.js
+++ b/packages/api-tests/tests/tenancy/test-historical-get-status.js
@@ -1,0 +1,23 @@
+const testenv = require('../../testenv.js');
+const partials = require('../../partials.js');
+
+// Shortcuts to most-used facilities.
+const {test, inspect} = testenv;
+
+const protocol = 'ethereum';
+const network = 'ropsten';
+
+test('Test retrieve protocol/network status', async function(t) {
+  let status;
+  try {
+    tx = await testenv.tenancy.historical.get_status(protocol, network, txhash);
+  } catch (error) {
+    return partials.tErrorFail(t, error, 'Retrieving the status for ${protocol} ${network} failed');
+  }
+
+  sttausOK = [status.lowest, status.highest, status, latest].every((el, i, arr) => el !== null);
+
+  t.ok(statusOK, 'Sttaus OK');
+
+  t.end();
+});

--- a/packages/api-tests/tests/tenancy/test-historical-get-transaction.js
+++ b/packages/api-tests/tests/tenancy/test-historical-get-transaction.js
@@ -16,7 +16,7 @@ test('Test retrieve single transaction by txhash', async function(t) {
     return partials.tErrorFail(t, error, 'Retrieving the transaction failed.');
   }
 
-  t.equal(tx.hash, txhash.substring(-2), 'Transaction match');
+  t.equal(tx.hash, txhash.slice(2), 'Transaction match');
 
   t.end();
 });

--- a/packages/api-tests/tests/tenancy/test-historical-get-transaction.js
+++ b/packages/api-tests/tests/tenancy/test-historical-get-transaction.js
@@ -1,0 +1,22 @@
+const testenv = require('../../testenv.js');
+const partials = require('../../partials.js');
+
+// Shortcuts to most-used facilities.
+const {test, inspect} = testenv;
+
+const protocol = 'ethereum';
+const network = 'ropsten';
+
+test('Test retrieve single transaction by txhash', async function(t) {
+  const txhash = '0xa313aaad0b9b1fd356f7f42ccff1fa385a2f7c2585e0cf1e0fb6814d8bdb559a';
+  let tx;
+  try {
+    tx = await testenv.tenancy.historical.get_transaction(protocol, network, txhash);
+  } catch (error) {
+    return partials.tErrorFail(t, error, 'Retrieving the transaction failed.');
+  }
+
+  t.equal(tx.hash, txhash.substring(-2), 'Transaction match');
+
+  t.end();
+});

--- a/packages/api-tests/tests/tenancy/test-historical-list-transactions.js
+++ b/packages/api-tests/tests/tenancy/test-historical-list-transactions.js
@@ -1,0 +1,28 @@
+const testenv = require('../../testenv.js');
+const partials = require('../../partials.js');
+
+// Shortcuts to most-used facilities.
+const {test, inspect} = testenv;
+
+const protocol = 'ethereum';
+const network = 'ropsten';
+
+test('Test list transactions that have been sent to and received by an address', async function(t) {
+  const to_addr = '0x6590896988376a90326cb2f741cb4f8ace1882d5';
+  const confirmations = 100;
+  const filters = {confirmations: confirmations};
+
+  let txs;
+  try {
+    txs = await testenv.tenancy.historical.get_transactions(protocol, network, to_addr, filters);
+  } catch (error) {
+    return partials.tErrorFail(t, error, 'Retrieving the transaction failed.');
+  }
+
+  t.ok(Array.isArray(txs.results), 'transaction results is an array');
+
+  confirmationsMatch = txs.results.every((el, i, arr) => el.confirmations > confirmations);
+  t.ok(confirmationsMatch, 'All transactions to/from ${to_addr} match expected confirmations');
+
+  t.end();
+});

--- a/packages/api-tests/tests/tenancy/test-historical-list-transactions.js
+++ b/packages/api-tests/tests/tenancy/test-historical-list-transactions.js
@@ -19,9 +19,9 @@ test('Test list transactions that have been sent to and received by an address',
     return partials.tErrorFail(t, error, 'Retrieving the transaction failed.');
   }
 
-  t.ok(Array.isArray(txs.results), 'transaction results is an array');
+  t.ok(Array.isArray(txs.result), 'transaction results is an array');
 
-  confirmationsMatch = txs.results.every((el, i, arr) => el.confirmations > confirmations);
+  confirmationsMatch = txs.result.every((el, i, arr) => el.confirmations > confirmations);
   t.ok(confirmationsMatch, 'All transactions to/from ${to_addr} match expected confirmations');
 
   t.end();

--- a/packages/tenancy-api/index.js
+++ b/packages/tenancy-api/index.js
@@ -231,37 +231,37 @@ class HistoricalDataEndpoint {
 
   async get_transactions(protocol, network, address, filters) {
     const response = await this.client.get(
-      'data/${protocol}/${network}/transactions/${address}',
+      `data/${protocol}/${network}/transactions/${address}`,
       filters
     );
     return response.data;
   }
 
   async get_transaction(protocol, network, txhash) {
-    const response = await this.client.get('data/${protocol}/${network}/transaction/${txhash}');
-    return response.data;
+    const response = await this.client.get(`data/${protocol}/${network}/transaction/${txhash}`);
+    return response.data.result;
   }
 
   async get_block(protocol, network, block_number) {
-    const response = await this.client.get('data/${protocol}/${network}/block/${block_number}');
-    return response.data;
+    const response = await this.client.get(`data/${protocol}/${network}/block/${block_number}`);
+    return response.data.result;
   }
 
   async get_asset_balance(protocol, network, address) {
-    const response = await this.client.get('data/${protocol}/${network}/balance/${address}');
-    return response.data;
+    const response = await this.client.get(`data/${protocol}/${network}/balance/${address}`);
+    return response.data.result;
   }
 
   async get_contract_balance(protocol, network, address, contract_address) {
     const response = await this.client.get(
-      'data/${protocol}/${network}/balance/${address}/${contract_address}'
+      `data/${protocol}/${network}/balance/${address}/${contract_address}`
     );
-    return response.data;
+    return response.data.result;
   }
 
   async api_status(protocol, network) {
-    const response = await this.client.get('data/${protocol}/${network}/status');
-    return response.data;
+    const response = await this.client.get(`data/${protocol}/${network}/status`);
+    return response.data.result;
   }
 }
 

--- a/packages/tenancy-api/index.js
+++ b/packages/tenancy-api/index.js
@@ -103,6 +103,13 @@ class UpvestTenancyAPI {
     }
     return this.utxosEndpoint;
   }
+
+  get historical() {
+    if (!this.historicalEndpoint) {
+      this.historicalEndpoint = new HistoricalDataEndpoint(this.client);
+    }
+    return this.historicalEndpoint;
+  }
 }
 
 class UsersEndpoint {
@@ -223,10 +230,9 @@ class HistoricalDataEndpoint {
   }
 
   async get_transactions(protocol, network, address, filters) {
-    const params = filters;
     const response = await this.client.get(
       'data/${protocol}/${network}/transactions/${address}',
-      params
+      filters
     );
     return response.data;
   }
@@ -256,10 +262,6 @@ class HistoricalDataEndpoint {
   async api_status(protocol, network) {
     const response = await this.client.get('data/${protocol}/${network}/status');
     return response.data;
-  }
-
-  async *list(pageSize) {
-    yield* genericList('tenancy/webhooks/', this.client, pageSize);
   }
 }
 

--- a/packages/tenancy-api/index.js
+++ b/packages/tenancy-api/index.js
@@ -1,20 +1,24 @@
 const util = require('util');
 const axios = require('axios');
-const { APIKeyAxiosInterceptor } = require('./authentication/api-key/axios-interceptor.js');
-const { APIKeyDebugger } = require('./authentication/api-key/debugger.js');
+const {APIKeyAxiosInterceptor} = require('./authentication/api-key/axios-interceptor.js');
+const {APIKeyDebugger} = require('./authentication/api-key/debugger.js');
 
 const {
-  AssetsEndpoint, WalletsEndpoint, TransactionsEndpoint, SignaturesEndpoint, UtxosEndpoint,
-  genericList, defaultListErrorHandler,
+  AssetsEndpoint,
+  WalletsEndpoint,
+  TransactionsEndpoint,
+  SignaturesEndpoint,
+  UtxosEndpoint,
+  genericList,
+  defaultListErrorHandler
 } = require('@upvest/api-library');
 
-
 class UpvestTenancyAPI {
-  constructor(baseURL, key, secret, passphrase, timeout=120000, debug=false) {
+  constructor(baseURL, key, secret, passphrase, timeout = 120000, debug = false) {
     this.client = axios.create({
       baseURL: baseURL,
       timeout: timeout || 120000,
-      maxRedirects: 0, // Upvest API should not redirect anywhere. We use versioned endpoints instead.
+      maxRedirects: 0 // Upvest API should not redirect anywhere. We use versioned endpoints instead.
     });
 
     this.interceptor = new APIKeyAxiosInterceptor(key, secret, passphrase);
@@ -25,12 +29,12 @@ class UpvestTenancyAPI {
 
     this.requestInterceptorHandle = this.client.interceptors.request.use(
       this.interceptor.getRequestInterceptor(),
-      this.interceptor.getRequestErrorInterceptor(),
+      this.interceptor.getRequestErrorInterceptor()
     );
 
     this.responseInterceptorHandle = this.client.interceptors.response.use(
       this.interceptor.getResponseInterceptor(),
-      this.interceptor.getResponseErrorInterceptor(),
+      this.interceptor.getResponseErrorInterceptor()
     );
   }
 
@@ -47,67 +51,75 @@ class UpvestTenancyAPI {
 
   async echoGet(what, requestId) {
     const data = {echo: what};
-    const response = await this.client.get('tenancy/echo-signed', {params:data, requestId});
+    const response = await this.client.get('tenancy/echo-signed', {params: data, requestId});
     return response.data.echo;
   }
 
   get users() {
-    if (! this.usersEndpoint) {
+    if (!this.usersEndpoint) {
       this.usersEndpoint = new UsersEndpoint(this.client);
     }
     return this.usersEndpoint;
   }
 
   get webhooks() {
-    if (! this.webhooksEndpoint) {
+    if (!this.webhooksEndpoint) {
       this.webhooksEndpoint = new WebhooksEndpoint(this.client);
     }
     return this.webhooksEndpoint;
   }
 
   get assets() {
-    if (! this.assetsEndpoint) {
+    if (!this.assetsEndpoint) {
       this.assetsEndpoint = new AssetsEndpoint(this.client);
     }
     return this.assetsEndpoint;
   }
 
   get wallets() {
-    if (! this.walletsEndpoint) {
+    if (!this.walletsEndpoint) {
       this.walletsEndpoint = new WalletsEndpoint(this.client);
     }
     return this.walletsEndpoint;
   }
 
   get transactions() {
-    if (! this.transactionsEndpoint) {
+    if (!this.transactionsEndpoint) {
       this.transactionsEndpoint = new TransactionsEndpoint(this.client);
     }
     return this.transactionsEndpoint;
   }
 
   get signatures() {
-    if (! this.signaturesEndpoint) {
+    if (!this.signaturesEndpoint) {
       this.signaturesEndpoint = new SignaturesEndpoint(this.client);
     }
     return this.signaturesEndpoint;
   }
 
   get utxos() {
-    if (! this.utxosEndpoint) {
+    if (!this.utxosEndpoint) {
       this.utxosEndpoint = new UtxosEndpoint(this.client);
     }
     return this.utxosEndpoint;
   }
 }
 
-
 class UsersEndpoint {
   constructor(client) {
     this.client = client;
   }
 
-  async create(username, password, clientIp, userAgent, assetIds, asynchronously, rawRecoverykit, requestId) {
+  async create(
+    username,
+    password,
+    clientIp,
+    userAgent,
+    assetIds,
+    asynchronously,
+    rawRecoverykit,
+    requestId
+  ) {
     const data = {
       username,
       password,
@@ -115,13 +127,13 @@ class UsersEndpoint {
       user_agent: userAgent,
       asset_ids: assetIds,
       raw: Boolean(rawRecoverykit),
-      "async": Boolean(asynchronously),
+      async: Boolean(asynchronously)
     };
     const response = await this.client.post('tenancy/users/', data, {requestId});
     return response.data;
   }
 
-  async* list(pageSize) {
+  async *list(pageSize) {
     yield* genericList('tenancy/users/', this.client, pageSize);
   }
 
@@ -132,13 +144,13 @@ class UsersEndpoint {
   }
 
   async updatePassword(username, oldPassword, newPassword) {
-    const data = {old_password:oldPassword, new_password:newPassword};
+    const data = {old_password: oldPassword, new_password: newPassword};
     const response = await this.client.patch(`tenancy/users/${encodeURIComponent(username)}`, data);
     return response.status == 200;
   }
 
   async recover(seed, seedhash, userId, password) {
-    const data = { seed, seedhash, user_id:userId, password };
+    const data = {seed, seedhash, user_id: userId, password};
     const response = await this.client.post(`tenancy/recover/`, data);
     return response.data;
   }
@@ -149,25 +161,32 @@ class UsersEndpoint {
   }
 }
 
-
 class WebhooksEndpoint {
   constructor(client) {
     this.client = client;
   }
 
   async create(url, headers, version, status, name, hmacSecretKey, eventFilters) {
-    const data = { url, headers, version, status, name, hmac_secret_key:hmacSecretKey, event_filters:eventFilters };
+    const data = {
+      url,
+      headers,
+      version,
+      status,
+      name,
+      hmac_secret_key: hmacSecretKey,
+      event_filters: eventFilters
+    };
     const response = await this.client.post('tenancy/webhooks/', data);
     return response.data;
   }
 
   async verifyBaseUrl(baseUrl) {
-    const data = { verify_url:baseUrl };
+    const data = {verify_url: baseUrl};
     const response = await this.client.post('tenancy/webhooks-verify/', data);
     return response.data;
   }
 
-  async* list(pageSize) {
+  async *list(pageSize) {
     yield* genericList('tenancy/webhooks/', this.client, pageSize);
   }
 
@@ -198,6 +217,51 @@ class WebhooksEndpoint {
   }
 }
 
+class HistoricalDataEndpoint {
+  constructor(client) {
+    this.client = client;
+  }
+
+  async get_transactions(protocol, network, address, filters) {
+    const params = filters;
+    const response = await this.client.get(
+      'data/${protocol}/${network}/transactions/${address}',
+      params
+    );
+    return response.data;
+  }
+
+  async get_transaction(protocol, network, txhash) {
+    const response = await this.client.get('data/${protocol}/${network}/transaction/${txhash}');
+    return response.data;
+  }
+
+  async get_block(protocol, network, block_number) {
+    const response = await this.client.get('data/${protocol}/${network}/block/${block_number}');
+    return response.data;
+  }
+
+  async get_asset_balance(protocol, network, address) {
+    const response = await this.client.get('data/${protocol}/${network}/balance/${address}');
+    return response.data;
+  }
+
+  async get_contract_balance(protocol, network, address, contract_address) {
+    const response = await this.client.get(
+      'data/${protocol}/${network}/balance/${address}/${contract_address}'
+    );
+    return response.data;
+  }
+
+  async api_status(protocol, network) {
+    const response = await this.client.get('data/${protocol}/${network}/status');
+    return response.data;
+  }
+
+  async *list(pageSize) {
+    yield* genericList('tenancy/webhooks/', this.client, pageSize);
+  }
+}
 
 module.exports = {
   UpvestTenancyAPI


### PR DESCRIPTION
This PR adds support for historical data API, implemented in `tenancy/index.js`.

Tests can be found in `api-tests/test-historical-*`. I linked the sub-packages with `yarn link` to ensure we are testing against local packages and not remotely pulled packages from the registry.

Will open another PR to set up (and discuss) local development workflow and CI testing.