### PR TITLE
Allow users to customize User Agent header

### DIFF
--- a/packages/api-library/index.js
+++ b/packages/api-library/index.js
@@ -1,3 +1,5 @@
+import {version} from '../../package.json';
+
 function defaultListErrorHandler(error, path) {
   console.log(`Caught error while trying to get ${path} list.`);
   if ('response' in error) {
@@ -198,7 +200,8 @@ class UtxosEndpoint {
 }
 
 function createHTTPClient(userAgent) {
-  const defaultUserAgent = 'Upvest-JS-API-Client/0.0.21';
+  //use actual package version from package.json
+  const defaultUserAgent = `Upvest-JS-API-Client/${version}`;
   client = axios.create({
     baseURL: baseURL,
     timeout: timeout || 120000,

--- a/packages/api-library/index.js
+++ b/packages/api-library/index.js
@@ -199,12 +199,12 @@ class UtxosEndpoint {
   }
 }
 
-function createHTTPClient(userAgent) {
+function createHTTPClient(config) {
   //use actual package version from package.json
   const defaultUserAgent = `Upvest-JS-API-Client/${version}`;
   client = axios.create({
-    baseURL: baseURL,
-    timeout: timeout || 120000,
+    baseURL: config.baseURL,
+    timeout: config.timeout || 120000,
     maxRedirects: 0, // Upvest API should not redirect anywhere. We use versioned endpoints instead.
   });
 

--- a/packages/api-library/index.js
+++ b/packages/api-library/index.js
@@ -208,7 +208,7 @@ function createHTTPClient(config) {
     maxRedirects: 0, // Upvest API should not redirect anywhere. We use versioned endpoints instead.
   });
 
-  client.defaults.headers.common['User-Agent'] = userAgent || defaultUserAgent;
+  client.defaults.headers.common['User-Agent'] = config.userAgent || defaultUserAgent;
 
   return client;
 }

--- a/packages/clientele-api/index.js
+++ b/packages/clientele-api/index.js
@@ -147,8 +147,7 @@ class UpvestClienteleAPIFromOAuth2Token extends BaseUpvestClienteleAPI {
     });
 
     // create the httpc leint
-    client = createHTTPClient(userAgent);
-
+    client = createHTTPClient({baseURL, timeout, userAgent});
     const requestInterceptorHandle = client.interceptors.request.use(
       // Wraps axios-token-interceptor with oauth-specific configuration,
       // fetches the token using the desired claim method, and caches

--- a/packages/clientele-api/index.js
+++ b/packages/clientele-api/index.js
@@ -3,8 +3,14 @@ const axios = require('axios');
 const oauth = require('axios-oauth-client');
 const tokenProvider = require('axios-token-interceptor');
 
-const { AssetsEndpoint, WalletsEndpoint, TransactionsEndpoint, SignaturesEndpoint, UtxosEndpoint } = require('@upvest/api-library');
-
+const {
+  AssetsEndpoint,
+  WalletsEndpoint,
+  TransactionsEndpoint,
+  SignaturesEndpoint,
+  UtxosEndpoint,
+  createHTTPClient,
+} = require('@upvest/api-library');
 
 class BaseUpvestClienteleAPI {
   constructor(client) {
@@ -19,72 +25,87 @@ class BaseUpvestClienteleAPI {
 
   async echoGet(what) {
     const data = {echo: what};
-    const response = await this.client.get('clientele/echo-oauth2', {params:data});
+    const response = await this.client.get('clientele/echo-oauth2', {params: data});
     return response.data.echo;
   }
 
   async offboard(password) {
-    const response = await this.client.post('clientele/offboard', { password }, { responseType: 'arraybuffer' });
+    const response = await this.client.post(
+      'clientele/offboard',
+      {password},
+      {responseType: 'arraybuffer'}
+    );
     return response.data;
   }
 
   get assets() {
-    if (! this.assetsEndpoint) {
+    if (!this.assetsEndpoint) {
       this.assetsEndpoint = new AssetsEndpoint(this.client);
     }
     return this.assetsEndpoint;
   }
 
   get wallets() {
-    if (! this.walletsEndpoint) {
+    if (!this.walletsEndpoint) {
       this.walletsEndpoint = new WalletsEndpoint(this.client);
     }
     return this.walletsEndpoint;
   }
 
   get transactions() {
-    if (! this.transactionsEndpoint) {
+    if (!this.transactionsEndpoint) {
       this.transactionsEndpoint = new TransactionsEndpoint(this.client);
     }
     return this.transactionsEndpoint;
   }
 
   get signatures() {
-    if (! this.signaturesEndpoint) {
+    if (!this.signaturesEndpoint) {
       this.signaturesEndpoint = new SignaturesEndpoint(this.client);
     }
     return this.signaturesEndpoint;
   }
 
   get utxos() {
-    if (! this.utxosEndpoint) {
+    if (!this.utxosEndpoint) {
       this.utxosEndpoint = new UtxosEndpoint(this.client);
     }
     return this.utxosEndpoint;
   }
 }
 
-
 class UpvestClienteleAPI extends BaseUpvestClienteleAPI {
-  constructor(baseURL, client_id, client_secret, username, password, scope=['read', 'write', 'echo', 'wallet', 'transaction'], timeout=120000) {
+  constructor(
+    baseURL,
+    client_id,
+    client_secret,
+    username,
+    password,
+    scope = ['read', 'write', 'echo', 'wallet', 'transaction'],
+    timeout = 120000
+  ) {
     const OAuth2TokenURL = baseURL + 'clientele/oauth2/token';
 
     const getFreshOAuth2Token = () => {
-      return oauth.client(axios.create(), {
-        url: OAuth2TokenURL,
-        grant_type: 'password',
-        client_id: client_id,
-        client_secret: client_secret,
-        username: username,
-        password: password,
-        scope: scope.join(' '),
-      })().then(token => {
-        token.granted_at = Date.now();
-        return token;
-      });
-    }
+      return oauth
+        .client(axios.create(), {
+          url: OAuth2TokenURL,
+          grant_type: 'password',
+          client_id: client_id,
+          client_secret: client_secret,
+          username: username,
+          password: password,
+          scope: scope.join(' '),
+        })()
+        .then(token => {
+          token.granted_at = Date.now();
+          return token;
+        });
+    };
 
-    const getCachedToken = tokenProvider.tokenCache(getFreshOAuth2Token, { getMaxAge: res => res.expires_in * 1000 });
+    const getCachedToken = tokenProvider.tokenCache(getFreshOAuth2Token, {
+      getMaxAge: res => res.expires_in * 1000,
+    });
 
     const client = axios.create({
       baseURL: baseURL,
@@ -96,7 +117,10 @@ class UpvestClienteleAPI extends BaseUpvestClienteleAPI {
       // Wraps axios-token-interceptor with oauth-specific configuration,
       // fetches the token using the desired claim method, and caches
       // until the token expires
-      tokenProvider({ getToken: getCachedToken, headerFormatter: res => 'Bearer ' + res.access_token })
+      tokenProvider({
+        getToken: getCachedToken,
+        headerFormatter: res => 'Bearer ' + res.access_token,
+      })
     );
 
     super(client);
@@ -106,32 +130,33 @@ class UpvestClienteleAPI extends BaseUpvestClienteleAPI {
   }
 }
 
-
 class UpvestClienteleAPIFromOAuth2Token extends BaseUpvestClienteleAPI {
-  constructor(baseURL, oauth2Token, timeout=120000) {
+  constructor(baseURL, oauth2Token, timeout = 120000, userAgent) {
     const OAuth2TokenURL = baseURL + 'clientele/oauth2/token';
 
     if (!oauth2Token.granted_at) {
-      oauth2Token.granted_at = Date.now();  // This default is most likely wrong, but we don't have anything better.
+      oauth2Token.granted_at = Date.now(); // This default is most likely wrong, but we don't have anything better.
     }
 
     oauth2Token.expires_in -= (Date.now() - oauth2Token.granted_at) / 1000;
 
     const getFreshOAuth2Token = () => Promise.resolve(oauth2Token);
 
-    const getCachedToken = tokenProvider.tokenCache(getFreshOAuth2Token, { getMaxAge: res => res.expires_in * 1000 });
-
-    const client = axios.create({
-      baseURL: baseURL,
-      timeout: timeout || 120000,
-      maxRedirects: 0, // Upvest API should not redirect anywhere. We use versioned endpoints instead.
+    const getCachedToken = tokenProvider.tokenCache(getFreshOAuth2Token, {
+      getMaxAge: res => res.expires_in * 1000,
     });
+
+    // create the httpc leint
+    client = createHTTPClient(userAgent);
 
     const requestInterceptorHandle = client.interceptors.request.use(
       // Wraps axios-token-interceptor with oauth-specific configuration,
       // fetches the token using the desired claim method, and caches
       // until the token expires
-      tokenProvider({ getToken: getCachedToken, headerFormatter: res => 'Bearer ' + res.access_token })
+      tokenProvider({
+        getToken: getCachedToken,
+        headerFormatter: res => 'Bearer ' + res.access_token,
+      })
     );
 
     super(client);
@@ -140,7 +165,6 @@ class UpvestClienteleAPIFromOAuth2Token extends BaseUpvestClienteleAPI {
     this.requestInterceptorHandle = requestInterceptorHandle;
   }
 }
-
 
 module.exports = {
   UpvestClienteleAPI,

--- a/packages/tenancy-api/index.js
+++ b/packages/tenancy-api/index.js
@@ -10,17 +10,13 @@ const {
   SignaturesEndpoint,
   UtxosEndpoint,
   genericList,
-  defaultListErrorHandler
+  defaultListErrorHandler,
+  createHTTPClient,
 } = require('@upvest/api-library');
 
 class UpvestTenancyAPI {
-  constructor(baseURL, key, secret, passphrase, timeout = 120000, debug = false) {
-    this.client = axios.create({
-      baseURL: baseURL,
-      timeout: timeout || 120000,
-      maxRedirects: 0 // Upvest API should not redirect anywhere. We use versioned endpoints instead.
-    });
-
+  constructor(baseURL, key, secret, passphrase, timeout = 120000, debug = false, userAgent) {
+    this.client = createHTTPClient(userAgent);
     this.interceptor = new APIKeyAxiosInterceptor(key, secret, passphrase);
 
     if (debug) {
@@ -134,7 +130,7 @@ class UsersEndpoint {
       user_agent: userAgent,
       asset_ids: assetIds,
       raw: Boolean(rawRecoverykit),
-      async: Boolean(asynchronously)
+      async: Boolean(asynchronously),
     };
     const response = await this.client.post('tenancy/users/', data, {requestId});
     return response.data;
@@ -181,7 +177,7 @@ class WebhooksEndpoint {
       status,
       name,
       hmac_secret_key: hmacSecretKey,
-      event_filters: eventFilters
+      event_filters: eventFilters,
     };
     const response = await this.client.post('tenancy/webhooks/', data);
     return response.data;
@@ -266,5 +262,5 @@ class HistoricalDataEndpoint {
 }
 
 module.exports = {
-  UpvestTenancyAPI
+  UpvestTenancyAPI,
 };

--- a/packages/tenancy-api/index.js
+++ b/packages/tenancy-api/index.js
@@ -16,7 +16,7 @@ const {
 
 class UpvestTenancyAPI {
   constructor(baseURL, key, secret, passphrase, timeout = 120000, debug = false, userAgent) {
-    this.client = createHTTPClient(userAgent);
+    this.client = createHTTPClient({baseURL, timeout, userAgent});
     this.interceptor = new APIKeyAxiosInterceptor(key, secret, passphrase);
 
     if (debug) {


### PR DESCRIPTION
I have added a function for creating an HTTP client, which takes in an optional user agent param.

This function is used in the Tenancy and Clientele classes to create the HTTP client. That means the clientele and tenancy now take in optional 'userAgent' param. This is just a quick fix, to avoid major changes now; I think we should rather pass in config object which is more flexible and can accommodate future changes. 